### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -2772,7 +2772,7 @@ function Main_SetHistoryworker() {
 
                             Main_history_UpdateLiveVod(
                                 event.data.data,
-                                event.data.updateobj._id.substr(1),
+                                event.data.updateobj._id.slice(1),
                                 ScreensObj_VodGetPreview(
                                     event.data.updateobj.preview.template,
                                     event.data.updateobj.animated_preview_url

--- a/app/specific/Play.js
+++ b/app/specific/Play.js
@@ -723,7 +723,7 @@ function Play_updateVodInfoSuccess(response, BroadcastID) {
 
             Main_history_UpdateLiveVod(
                 BroadcastID,
-                response[i]._id.substr(1),
+                response[i]._id.slice(1),
                 ScreensObj_VodGetPreview(response[i].preview.template, response[i].animated_preview_url)
             );
 

--- a/app/specific/ScreensObj.js
+++ b/app/specific/ScreensObj.js
@@ -2314,7 +2314,7 @@ function ScreensObj_VodCellArray(cell) {
         Main_addCommas(cell.views),//4
         cell.resolutions.chunked ? Main_videoqualitylang(cell.resolutions.chunked.slice(-4), (parseInt(cell.fps.chunked) || 0), cell.channel.broadcaster_language) : '',//5
         cell.channel.name,//6
-        cell._id.substr(1),//7
+        cell._id.slice(1),//7
         cell.animated_preview_url,//8
         cell.channel.broadcaster_language,//9
         twemoji.parse(cell.title),//10

--- a/app/thirdparty/kapchat.js
+++ b/app/thirdparty/kapchat.js
@@ -50,14 +50,14 @@ function findCheerInToken(message, chat_number) {
     for (i; i < len; i++) {
         //Try  case sensitive first as some prefixes start the same, but some users type without carrying about case
         if (Main_startsWith(message, cheerPrefixes[i]))
-            return getCheer(cheerPrefixes[i], parseInt(message.substr(cheerPrefixes[i].length), 10), chat_number);
+            return getCheer(cheerPrefixes[i], parseInt(message.slice(cheerPrefixes[i].length), 10), chat_number);
 
         //Try  case insensitive after
         if (Main_startsWith(tokenLower, cheerPrefixes[i].toLowerCase())) index = i;
     }
 
     return ((index > -1) ?
-        getCheer(cheerPrefixes[index], parseInt(tokenLower.substr(cheerPrefixes[index].toLowerCase().length), 10), chat_number)
+        getCheer(cheerPrefixes[index], parseInt(tokenLower.slice(cheerPrefixes[index].toLowerCase().length), 10), chat_number)
         : null);
 }
 
@@ -138,10 +138,10 @@ function emoticonize(message, emotes) {
 //     }
 
 //     for (i = 0; i < 3; i++) {
-//         c = parseInt(color.substr(i * 2, 2), 16);
+//         c = parseInt(color.slice(i * 2, i * 2 + 2), 16);
 //         if (c < 10) c = 10;
 //         c = Math.round(Math.min(Math.max(0, c + (c * brightness)), 255)).toString(16);
-//         rgb += ("00" + c).substr(c.length);
+//         rgb += ("00" + c).slice(c.length);
 //     }
 
 //     return rgb;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.