### PR TITLE
fix 7tv emotes by updating to v3 api

### DIFF
--- a/app/specific/ChatLive.js
+++ b/app/specific/ChatLive.js
@@ -849,7 +849,7 @@ function ChatLive_seven_tv_getEmoteUrl(emoteBaseUrl, emote) {
     var actualEmoteUrl = emoteBaseUrl;
 
     // emote url is like //cdn.7tv.app/emote/5f5e0e9f8f0a1c3720f6e0e2
-    if (!Main_startsWith(emoteBaseUrl, 'http')) {
+    if (Main_startsWith(emoteBaseUrl, '//')) {
         actualEmoteUrl = 'https://' + emoteBaseUrl;
     }
 

--- a/app/specific/ChatLive.js
+++ b/app/specific/ChatLive.js
@@ -796,6 +796,9 @@ function ChatLive_loadEmotesseven_tv(data, chat_number, isGlobal) {
                 return;
             }
 
+            // the name on the outer emote object is the actual name to use
+            emote.name = seven_tv_emote.name
+
             // files can contain multiple emote formats
             emoteUrls = ChatLive_seven_tv_filterEmoteFiles(emote.host.files);
             if (!emoteUrls.length) {

--- a/app/specific/ChatVod.js
+++ b/app/specific/ChatVod.js
@@ -405,7 +405,7 @@ function Chat_loadEmotesbttvGlobal(data) {
 
 function Chat_loadSeven_tvGlobalEmotes() {
     if (!extraEmotesDone.Seven_tvGlobal) {
-        Chat_BaseLoadUrl('https://api.7tv.app/v2/emotes/global', Chat_loadEmotesSuccessSeven_tv, noop_fun);
+        Chat_BaseLoadUrl('https://7tv.io/v3/emote-sets/global', Chat_loadEmotesSuccessSeven_tv, noop_fun);
     } else {
         ChatLive_updateExtraEmotes(extraEmotesDone.seven_tvGlobal, 0);
         ChatLive_updateExtraEmotes(extraEmotesDone.seven_tvGlobal, 1);
@@ -413,7 +413,13 @@ function Chat_loadSeven_tvGlobalEmotes() {
 }
 
 function Chat_loadEmotesSuccessSeven_tv(data) {
-    ChatLive_loadEmotesseven_tv(JSON.parse(data), 0, true);
+    var emotes = [];
+    var data = JSON.parse(data);
+    if (data && data.emotes) {
+        emotes = data.emotes || [];
+    }
+
+    ChatLive_loadEmotesseven_tv(emotes, 0, true);
 }
 
 function Chat_loadEmotesffz() {


### PR DESCRIPTION
7tv emotes no longer load as the v2 api no longer exists, this updates the code to use the v3 api.

i tried to keep it in the style of existing code. it worked for me when testing on my browser but i can't test on a tv.

7tv returns AVIF emotes now, i'm not sure if these are supported but i made the code filter them out so only webp is used.