### PR TITLE
Display flag instead of language code to improve readability

### DIFF
--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -931,6 +931,82 @@ function Main_GetViewsStrings(value) {
     return value === 1 ? STR_VIEW : STR_VIEWS;
 }
 
+const TWITCH_LANGUAGE_TO_COUNTRY = {
+    // Europe
+    fr: "FR",
+    en: "GB",
+    ca: "ES",
+    da: "DK",
+    de: "DE",
+    es: "ES",
+    it: "IT",
+    hu: "HU",
+    nl: "NL",
+    no: "NO",
+    pl: "PL",
+    pt: "PT",
+    ro: "RO",
+    sk: "SK",
+    fi: "FI",
+    sv: "SE",
+    tr: "TR",
+    cs: "CZ",
+    el: "GR",
+    bg: "BG",
+    ru: "RU",
+    uk: "UA",
+
+    // Asia / Middle-East
+    id: "ID",
+    vi: "VN",
+    ms: "MY",
+    hi: "IN",
+    th: "TH",
+    zh: "CN",
+    "zh-hk": "HK",
+    ja: "JP",
+    ko: "KR",
+    ar: "SA",
+
+    // Other
+    tl: "PH",
+    asl: "US",
+    other: null
+};
+
+function countryCodeToFlagEmoji(code) {
+    if (!code || typeof code !== "string") return null;
+
+    const cc = code.toUpperCase();
+    if (!/^[A-Z]{2}$/.test(cc)) return null;
+
+    const A = 0x1f1e6;
+    return String.fromCodePoint(
+        A + cc.charCodeAt(0) - 65,
+        A + cc.charCodeAt(1) - 65
+    );
+}
+
+function Main_FormatLanguage(code) {
+    if (!code) return "[??]";
+
+    const normalized = code.toLowerCase();
+    const base = normalized.split("-")[0];
+
+    const countryCode =
+        TWITCH_LANGUAGE_TO_COUNTRY[normalized] ??
+        TWITCH_LANGUAGE_TO_COUNTRY[base];
+
+    const flag = countryCode
+        ? countryCodeToFlagEmoji(countryCode)
+        : null;
+
+    if (flag) return flag;
+
+    return `[${base.toUpperCase()}]`;
+}
+
+
 // function Main_videoqualitylang(video_height, average_fps, language) {
 //     video_height = video_height + ''; //stringfy doesnot work 8|
 //     if (!video_height.indexOf('x')) video_height = video_height.slice(-3);

--- a/app/specific/ScreensObj.js
+++ b/app/specific/ScreensObj.js
@@ -3003,7 +3003,7 @@ function ScreensObj_LiveQueryCellArray(cell) {
         cell.stream.title, //2
         game ? game.displayName : '', //3
         Main_formatNumber(cell.stream.viewersCount), //4
-        broadcaster && broadcaster.language ? '[' + broadcaster.language.toUpperCase() + ']' : '', //5
+        broadcaster && broadcaster.language ? Main_FormatLanguage(broadcaster.language) : '', //5
         broadcaster ? broadcaster.login : '', //6
         cell.stream.id.toString(), //7 broadcast id
         Main_is_rerun(cell.stream.type), //8


### PR DESCRIPTION
This is a feature suggestion.

Live cards contain a lot of text and I think it would be intersting to reduce text on it.
This MR replace language name wirth corresponding country flag. It includes an exhaustive mapping of Twitch stream languages.

Preview : 
<img width="2462" height="1382" alt="localhost_8000_app_" src="https://github.com/user-attachments/assets/ff79108b-e586-41c0-8052-afc1daeaa12f" />
