### PR TITLE
Improve fullscreen chat customization and add pinned mentions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1682,6 +1682,7 @@
                 width: 24.7%;
                 height: 48%;
                 background-color: rgba(0, 0, 0, 0.5);
+                overflow: hidden;
             }
 
             .chat_container1 {
@@ -2291,7 +2292,7 @@
             }
 
             .chat_line_holder {
-                overflow: hidden;
+                overflow: visible;
             }
 
             .chat_line_animation {
@@ -2320,10 +2321,10 @@
             }
 
             .chat_line_slim {
-                padding-bottom: 0 !important;
+                padding-bottom: 0.22em !important;
                 padding-top: 0.12em !important;
                 margin-bottom: 0 !important;
-                line-height: 1em !important;
+                line-height: 1.2em !important;
             }
 
             .chat_loggedin {
@@ -2345,10 +2346,73 @@
                 overflow: hidden;
             }
 
+            .chat_pinned_holder {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                z-index: 4;
+                overflow: hidden;
+                padding: 0.18em 0.22em 0.24em 0.22em;
+                border: 0.05em solid rgba(255, 214, 74, 0.45);
+                border-radius: 0 0 0.2em 0.2em;
+                background: linear-gradient(180deg, rgba(57, 69, 15, 0.96) 0%, rgba(17, 48, 10, 0.92) 100%);
+                box-shadow: 0 0.12em 0.4em rgba(0, 0, 0, 0.35);
+                box-sizing: border-box;
+            }
+
+            .chat_pinned_holder.hide {
+                display: none;
+            }
+
+            .chat_pinned_holder .chat_line {
+                margin-bottom: 0.1em;
+                padding-top: 0.08em !important;
+                padding-bottom: 0.08em !important;
+                background: rgba(0, 0, 0, 0.18);
+                border-left: 0.18em solid rgba(255, 214, 74, 0.7);
+            }
+
+            .chat_pinned_header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 0.12em;
+                color: #ffe892;
+                font-family: 'Roboto-Bold';
+                font-size: 0.82em;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+            }
+
+            .chat_pinned_label {
+                display: inline-block;
+            }
+
+            .chat_pinned_count {
+                color: rgba(255, 255, 255, 0.72);
+                font-size: 0.92em;
+            }
+
+            .chat_pinned_age {
+                float: right;
+                margin-left: 0.5em;
+                color: rgba(255, 255, 255, 0.8);
+                font-size: 0.78em;
+                font-family: 'Roboto-Bold';
+            }
+
             .chat_box_holder {
                 height: 100%;
                 transform: rotate(180deg);
                 overflow: hidden;
+            }
+
+            .chat_box_stack {
+                transform: rotate(180deg);
+                min-height: 100%;
+                box-sizing: border-box;
+                padding-bottom: 0;
             }
 
             .tag {
@@ -2389,6 +2453,7 @@
             }
 
             .chat_size {
+                position: relative;
                 width: 100%;
                 height: 100%;
             }
@@ -3501,8 +3566,9 @@
                 <div id="chat_container0" class="chat_container hide">
                     <div id="chat_inner_container0" class="chat_size">
                         <div id="chat_loggedin0" class="chat_loggedin hide"></div>
+                        <div id="chat_pinned_holder0" class="chat_pinned_holder hide"></div>
                         <div id="chat_box_holder0" class="chat_box_holder">
-                            <div style="transform: rotate(180deg)">
+                            <div class="chat_box_stack">
                                 <div id="chat_box0"></div>
                             </div>
                         </div>
@@ -3514,8 +3580,9 @@
                 <div id="chat_container1" class="chat_container1 hide">
                     <div id="chat_inner_container1" class="chat_size">
                         <div id="chat_loggedin1" class="chat_loggedin hide"></div>
+                        <div id="chat_pinned_holder1" class="chat_pinned_holder hide"></div>
                         <div id="chat_box_holder1" class="chat_box_holder">
-                            <div style="transform: rotate(180deg)">
+                            <div class="chat_box_stack">
                                 <div id="chat_box1"></div>
                             </div>
                         </div>

--- a/app/specific/ChatLive.js
+++ b/app/specific/ChatLive.js
@@ -59,6 +59,8 @@ var ChatLive_StartSharedId = [];
 var ChatLive_PingId = [];
 var ChatLive_SendPingId;
 var ChatLive_selectedChannel = [];
+var ChatLive_PinnedMessages = [];
+var ChatLive_PinnedCleanupId = [];
 var ChatLive_sub_replace = new RegExp('\\\\s', 'gi');
 var ChatLive_chat_line_class = '';
 
@@ -151,6 +153,14 @@ function ChatLive_Switch() {
     Chat_div[1].innerHTML = Chat_div[0].innerHTML;
     Chat_div[0].innerHTML = innerHTMLTemp;
 
+    innerHTMLTemp = ChatPinned_div[1].innerHTML;
+    ChatPinned_div[1].innerHTML = ChatPinned_div[0].innerHTML;
+    ChatPinned_div[0].innerHTML = innerHTMLTemp;
+
+    innerHTMLTemp = ChatLive_PinnedMessages[1];
+    ChatLive_PinnedMessages[1] = ChatLive_PinnedMessages[0];
+    ChatLive_PinnedMessages[0] = innerHTMLTemp;
+
     var logged0 = Main_getElementById('chat_loggedin0'),
         logged1 = Main_getElementById('chat_loggedin1');
 
@@ -159,6 +169,9 @@ function ChatLive_Switch() {
     logged0.innerHTML = innerHTMLTemp;
 
     for (var i = 0; i < 2; i++) {
+        ChatLive_RenderPinnedMessages(i);
+        ChatLive_SchedulePinnedCleanup(i);
+        ChatLive_UpdateLayout(i);
         ChatLive_Close(i);
         ChatLive_Init(i, true);
     }
@@ -178,8 +191,12 @@ var ChatLive_Individual_Background_flip = [];
 var ChatLive_Highlight_Actions;
 var ChatLive_Highlight_Bits;
 var ChatLive_Show_SUB;
+var ChatLive_PinMentions;
+var ChatLive_PinMentionsCount;
+var ChatLive_PinMentionsTimeout;
 var ChatLive_User_Set;
 var chat_lineChatLive_Individual_Lines;
+var ChatLive_PinMentionsTimeVal = [30000, 60000, 120000, 300000, 600000, 900000, 1800000];
 var chat_Line_highlight_green = ' style="color: #4eff42;" ';
 var chat_Line_highlight_blue = ' style="color: #4AA4FD;" ';
 var ChatLive_User_Regex_Search;
@@ -193,6 +210,30 @@ var ChatLive_HideBots;
 var ChatLive_ShowBadges;
 var ChatLive_ShowBadgesMod;
 var ChatLive_ShowBadgesVIP;
+
+function ChatLive_RefreshPinSettings() {
+    var pinDefault = Settings_value.pin_mentions.defaultValue,
+        countDefault = Settings_value.pin_mentions_count.defaultValue,
+        timeDefault = Settings_value.pin_mentions_time.defaultValue,
+        i;
+
+    ChatLive_PinMentions = ChatLive_User_Set && Main_getItemInt('Play_ChatPinMentions', pinDefault);
+    ChatLive_PinMentionsCount = Main_getItemInt('Play_ChatPinMentionsCount', countDefault) + 1;
+    ChatLive_PinMentionsTimeout =
+        ChatLive_PinMentionsTimeVal[Main_getItemInt('Play_ChatPinMentionsTime', timeDefault)] || ChatLive_PinMentionsTimeVal[2];
+
+    for (i = 0; i < 2; i++) {
+        if (!ChatLive_PinMentions) {
+            Main_clearTimeout(ChatLive_PinnedCleanupId[i]);
+            ChatLive_PinnedMessages[i] = [];
+        }
+
+        if (typeof ChatPinned_div !== 'undefined' && ChatPinned_div[i]) {
+            ChatLive_RenderPinnedMessages(i);
+            ChatLive_SchedulePinnedCleanup(i);
+        }
+    }
+}
 
 function ChatLive_SetOptions(chat_number, Channel_id, selectedChannel) {
     extraEmotes[chat_number] = {};
@@ -215,6 +256,7 @@ function ChatLive_SetOptions(chat_number, Channel_id, selectedChannel) {
     ChatLive_Highlight_Mod = Settings_value.highlight_mod.defaultValue;
     ChatLive_Highlight_AtUser = ChatLive_User_Set && Settings_value.highlight_atuser.defaultValue;
     ChatLive_Highlight_User_send = ChatLive_User_Set && Settings_value.highlight_user_send.defaultValue;
+    ChatLive_RefreshPinSettings();
     ChatLive_Highlight_Actions = Settings_value.show_actions.defaultValue;
     ChatLive_Highlight_Bits = Settings_value.highlight_bits.defaultValue;
     ChatLive_Show_SUB = Settings_value.show_sub.defaultValue;
@@ -464,8 +506,7 @@ function ChatLive_loadBadgesChannelSuccess(obj, id, chat_number, channelId) {
 function ChatLive_resetChatters(chat_number) {
     Main_textContent('chat_loggedin' + chat_number, '');
     Main_AddClass('chat_loggedin' + chat_number, 'hide');
-    Main_getElementById('chat_box_holder' + chat_number).style.height = '';
-    Main_getElementById('chat_container_name' + chat_number).style.top = '';
+    ChatLive_UpdateLayout(chat_number);
 }
 
 function ChatLive_loadChatters(chat_number, id) {
@@ -476,12 +517,7 @@ function ChatLive_loadChatters(chat_number, id) {
                 (Settings_value.show_chatters.defaultValue === 1 ? (ChatLive_isShared[chat_number] ? STR_IN_SHARED_CHAT : STR_IN_CHAT) : STR_VIEWERS)
         );
         Main_RemoveClass('chat_loggedin' + chat_number, 'hide');
-
-        Main_getElementById('chat_box_holder' + chat_number).style.height = 'calc(100% - 2.9vh)';
-
-        if (!chat_number) {
-            Main_getElementById('chat_container_name' + chat_number).style.top = '3vh';
-        }
+        ChatLive_UpdateLayout(chat_number);
 
         ChatLive_loadChattersCheckType(chat_number, id);
     }
@@ -1799,18 +1835,20 @@ function ChatLive_loadChatSuccess(message, chat_number, addToStart) {
             .trim();
     }
 
+    var mentionsUser = ChatLive_User_Set && ChatLive_User_Regex_Search.test(mmessage),
+        isFromUser =
+            ChatLive_User_Set &&
+            Main_A_equals_B(tags['display-name'].toLowerCase(), AddUser_UsernameArray[0].display_name.toLowerCase());
+
     if (ChatLive_Highlight_AtStreamer && ChatLive_Channel_Regex_Search[chat_number].test(mmessage)) {
         atstreamer = true;
     } else if (ChatLive_Highlight_FromStreamer && Main_A_equals_B(tags['display-name'].toLowerCase(), ChatLive_selectedChannel[chat_number])) {
         fromstreamer = true;
     } else if (ChatLive_Highlight_Mod && tags.mod && tags.mod !== '0') {
         mod = true;
-    } else if (ChatLive_Highlight_AtUser && ChatLive_User_Regex_Search.test(mmessage)) {
+    } else if (ChatLive_Highlight_AtUser && mentionsUser) {
         atuser = true;
-    } else if (
-        ChatLive_Highlight_User_send &&
-        Main_A_equals_B(tags['display-name'].toLowerCase(), AddUser_UsernameArray[0].display_name.toLowerCase())
-    ) {
+    } else if (ChatLive_Highlight_User_send && isFromUser) {
         atuser = true;
     }
 
@@ -1850,6 +1888,7 @@ function ChatLive_loadChatSuccess(message, chat_number, addToStart) {
         atuser: atuser,
         fromstreamer: fromstreamer,
         mod: mod,
+        mentionsUser: mentionsUser,
         firstTimer: firstTimer,
         hasbits: hasbits && ChatLive_Highlight_Bits,
         extraMessage: extraMessage,
@@ -1980,6 +2019,9 @@ function ChatLive_LineAddSimple(message) {
 function ChatLive_LineAdd(messageObj) {
     if (ChatLive_Playing) {
         ChatLive_ElementAdd(messageObj);
+        if (ChatLive_PinMentions && messageObj.mentionsUser) {
+            ChatLive_PinMessage(messageObj);
+        }
 
         if (ChatLive_LineAddCounter[messageObj.chat_number]++ > Chat_CleanMax) {
             ChatLive_LineAddCounter[messageObj.chat_number] = 0;
@@ -1988,6 +2030,121 @@ function ChatLive_LineAdd(messageObj) {
     } else {
         ChatLive_Messages[messageObj.chat_number].push(messageObj);
     }
+}
+
+function ChatLive_UpdateLayout(chat_number) {
+    var logged = Main_getElementById('chat_loggedin' + chat_number),
+        pinned = ChatPinned_div[chat_number],
+        boxHolder = Main_getElementById('chat_box_holder' + chat_number),
+        nameHolder = Main_getElementById('chat_container_name' + chat_number),
+        extraHeight = 0;
+
+    if (!Main_A_includes_B(logged.className, 'hide')) {
+        extraHeight += logged.offsetHeight;
+    }
+
+    if (pinned) {
+        pinned.style.top = extraHeight ? extraHeight + 'px' : '0';
+    }
+
+    if (extraHeight) {
+        boxHolder.style.height = 'calc(100% - ' + extraHeight + 'px)';
+        if (nameHolder) {
+            nameHolder.style.top = extraHeight + 2 + 'px';
+        }
+    } else {
+        boxHolder.style.height = '';
+        if (nameHolder) {
+            nameHolder.style.top = '';
+        }
+    }
+}
+
+function ChatLive_PrunePinnedMessages(chat_number) {
+    var messages = ChatLive_PinnedMessages[chat_number],
+        now = new Date().getTime();
+
+    if (!messages || !messages.length) {
+        return;
+    }
+
+    ChatLive_PinnedMessages[chat_number] = messages.filter(function (item) {
+        return item.expiresAt > now;
+    });
+
+    if (ChatLive_PinnedMessages[chat_number].length > ChatLive_PinMentionsCount) {
+        ChatLive_PinnedMessages[chat_number].length = ChatLive_PinMentionsCount;
+    }
+}
+
+function ChatLive_RenderPinnedMessages(chat_number) {
+    var pinnedHolder = ChatPinned_div[chat_number],
+        messages = ChatLive_PinnedMessages[chat_number],
+        markup = '';
+
+    if (!pinnedHolder) {
+        return;
+    }
+
+    ChatLive_PrunePinnedMessages(chat_number);
+    messages = ChatLive_PinnedMessages[chat_number];
+
+    if (messages && messages.length) {
+        markup =
+            '<div class="chat_pinned_header"><span class="chat_pinned_label">Pinned mentions</span><span class="chat_pinned_count">' +
+            messages.length +
+            '</span></div>' +
+            messages
+            .map(function (item) {
+                return ChatLive_BuildPinnedLineMarkup(item);
+            })
+            .join('');
+        Main_innerHTMLWithEle(pinnedHolder, markup);
+        Main_RemoveClass('chat_pinned_holder' + chat_number, 'hide');
+    } else {
+        Main_emptyWithEle(pinnedHolder);
+        Main_AddClass('chat_pinned_holder' + chat_number, 'hide');
+    }
+
+    ChatLive_UpdateLayout(chat_number);
+}
+
+function ChatLive_SchedulePinnedCleanup(chat_number) {
+    var messages = ChatLive_PinnedMessages[chat_number],
+        nextTimeout = 1000,
+        now = new Date().getTime();
+
+    Main_clearTimeout(ChatLive_PinnedCleanupId[chat_number]);
+
+    if (!messages || !messages.length) {
+        return;
+    }
+
+    ChatLive_PinnedCleanupId[chat_number] = Main_setTimeout(function () {
+        ChatLive_RenderPinnedMessages(chat_number);
+        ChatLive_SchedulePinnedCleanup(chat_number);
+    }, nextTimeout, ChatLive_PinnedCleanupId[chat_number]);
+}
+
+function ChatLive_PinMessage(messageObj) {
+    var chat_number = messageObj.chat_number,
+        messages = ChatLive_PinnedMessages[chat_number];
+
+    if (!messages) {
+        messages = [];
+        ChatLive_PinnedMessages[chat_number] = messages;
+    }
+
+    messages.unshift({
+        message: messageObj.message,
+        mentionsUser: messageObj.mentionsUser,
+        createdAt: new Date().getTime(),
+        expiresAt: new Date().getTime() + ChatLive_PinMentionsTimeout
+    });
+
+    ChatLive_PrunePinnedMessages(chat_number);
+    ChatLive_RenderPinnedMessages(chat_number);
+    ChatLive_SchedulePinnedCleanup(chat_number);
 }
 
 //Full messageObj current is
@@ -2043,7 +2200,7 @@ function ChatLive_ElementAdd(messageObj) {
     if (chat_lineChatLive_Individual_Lines && !messageObj.skip_addline) classname += ' chat_line_ind';
     else classname += ' chat_line_slim';
 
-    var chat_line = '<div style="' + style + '" class="' + classname + '">' + messageObj.message + '</div>';
+    var chat_line = ChatLive_BuildLineMarkup(messageObj, style, classname);
 
     // <div class="chat_line chat_line_ind">
     // <span style="color: #D463FF;">USER Name</span>:&nbsp;
@@ -2064,6 +2221,35 @@ function ChatLive_ElementAdd(messageObj) {
         Chat_div[messageObj.chat_number].insertBefore(chat_line_holder, Chat_div[messageObj.chat_number].childNodes[0]);
         ChatLive_ElementAddCheckExtra(messageObj);
     }
+}
+
+function ChatLive_BuildLineMarkup(messageObj, style, classname) {
+    return '<div style="' + style + '" class="' + classname + '">' + messageObj.message + '</div>';
+}
+
+function ChatLive_GetPinnedAge(createdAt) {
+    var seconds = Math.max(Math.floor((new Date().getTime() - createdAt) / 1000), 0);
+
+    if (seconds < 60) {
+        return seconds + 's ago';
+    }
+
+    if (seconds < 3600) {
+        return Math.floor(seconds / 60) + 'm ago';
+    }
+
+    return Math.floor(seconds / 3600) + 'h ago';
+}
+
+function ChatLive_BuildPinnedLineMarkup(messageObj) {
+    var message = messageObj.message,
+        age = ChatLive_GetPinnedAge(messageObj.createdAt);
+
+    if (messageObj.mentionsUser && ChatLive_User_Regex_Replace) {
+        message = message.replace(ChatLive_User_Regex_Replace, "<span style='color: #34B5FF; font-weight: bold'>$&</span>");
+    }
+
+    return '<div class="chat_line chat_atuser chat_line_slim"><span class="chat_pinned_age">' + age + '</span>' + message + '</div>';
 }
 
 function ChatLive_ElementAddCheckExtra(messageObj) {
@@ -2134,13 +2320,18 @@ function ChatLive_ClearIds(chat_number) {
 
 function ChatLive_Clear(chat_number) {
     ChatLive_ClearIds(chat_number);
+    Main_clearTimeout(ChatLive_PinnedCleanupId[chat_number]);
 
     Chat_Id[chat_number] = 0;
     ChatLive_LineAddCounter[chat_number] = 0;
     ChatLive_Messages[chat_number] = [];
+    ChatLive_PinnedMessages[chat_number] = [];
 
     ChatLive_resetChatters(chat_number);
     Main_emptyWithEle(Chat_div[chat_number]);
+    Main_emptyWithEle(ChatPinned_div[chat_number]);
+    Main_AddClass('chat_pinned_holder' + chat_number, 'hide');
+    ChatLive_UpdateLayout(chat_number);
 
     ChatLive_loaded[chat_number] = false;
     ChatLive_Banned[chat_number] = false;

--- a/app/specific/ChatVod.js
+++ b/app/specific/ChatVod.js
@@ -55,6 +55,7 @@ var defaultColors = [
 
 var defaultColorsLength = defaultColors.length;
 var Chat_div = [];
+var ChatPinned_div = [];
 var Chat_Position = 0;
 var Chat_hasEnded = false;
 var Chat_CleanMax = 60;
@@ -74,6 +75,8 @@ var Chat_UserJPKRegex = new RegExp('[^\x00-\x7F]', 'g');
 function Chat_Preinit() {
     Chat_div[0] = Main_getElementById('chat_box0');
     Chat_div[1] = Main_getElementById('chat_box1');
+    ChatPinned_div[0] = Main_getElementById('chat_pinned_holder0');
+    ChatPinned_div[1] = Main_getElementById('chat_pinned_holder1');
     ChatLive_LineAddCounter[0] = 0;
     ChatLive_LineAddCounter[1] = 0;
     ChatLive_Messages[0] = [];

--- a/app/specific/Play.js
+++ b/app/specific/Play.js
@@ -22,8 +22,11 @@
 var Play_ChatPositions = 0;
 var Play_ChatPositionConvertBefore = Play_ChatPositions;
 var Play_ChatBackground = 0.55;
-var Play_ChatSizeValue = 4;
-var Play_MaxChatSizeValue = 4;
+var Play_ChatSizeValue = 99;
+var Play_MaxChatSizeValue = 99;
+var Play_ChatWidthValue = 24;
+var Play_ChatOffsetXValue = 0;
+var Play_ChatOffsetYValue = 0;
 var Play_PanelHideID = null;
 var Play_isFullScreen = true;
 var PlayVod_RefreshProgressBarrTimeout = 1000;
@@ -78,47 +81,38 @@ var Play_base_chat_headers_Array = [];
 var Play_base_kraken_headers_Array = [];
 
 //counterclockwise movement, Vertical/horizontal Play_ChatPositions
-//sizeOffset in relation to the size
 var Play_ChatPositionVal = [
     {
-        top: 51.8, // Bottom/right 0
-        left: 75.1,
-        sizeOffset: [31, 16, 0, -25.2, 0] // top - sizeOffset is the defaul top for it chat position
+        vertical: 'bottom',
+        horizontal: 'right'
     },
     {
-        top: 33, // Middle/right 1
-        left: 75.1,
-        sizeOffset: [12.5, 0, -6.25, -19.5, 0]
+        vertical: 'center',
+        horizontal: 'right'
     },
     {
-        top: 0.2, // Top/right 2
-        left: 75.1,
-        sizeOffset: [0, 0, 0, 0, 0]
+        vertical: 'top',
+        horizontal: 'right'
     },
     {
-        top: 0.2, // Top/center 3
-        left: 38.3,
-        sizeOffset: [0, 0, 0, 0, 0]
+        vertical: 'top',
+        horizontal: 'center'
     },
     {
-        top: 0.2, // Top/left 4
-        left: 0.2,
-        sizeOffset: [0, 0, 0, 0, 0]
+        vertical: 'top',
+        horizontal: 'left'
     },
     {
-        top: 33, // Middle/left 5
-        left: 0.2,
-        sizeOffset: [12.5, 0, -6.25, -19.5, 0]
+        vertical: 'center',
+        horizontal: 'left'
     },
     {
-        top: 51.8, // Bottom/left 6
-        left: 0.2,
-        sizeOffset: [31, 16, 0, -25.2, 0]
+        vertical: 'bottom',
+        horizontal: 'left'
     },
     {
-        top: 51.8, // Bottom/center 7
-        left: 38.3,
-        sizeOffset: [31, 16, 0, -25.2, 0]
+        vertical: 'bottom',
+        horizontal: 'center'
     }
 ];
 
@@ -131,35 +125,33 @@ var Play_ChatPositionsAfter = [
     [6, 5, 4, 4, 4, 5, 6, 6]
 ];
 
-var Play_ChatSizeVal = [
-    {
-        containerHeight: 17, // 12.5%
-        percentage: '12.5%',
-        dialogTop: -25
-    },
-    {
-        containerHeight: 32, // 25%
-        percentage: '25%',
-        dialogTop: -40
-    },
-    {
-        containerHeight: 48, // 50%
-        percentage: '50%',
-        dialogTop: -60
-    },
-    {
-        containerHeight: 73, // 75%
-        percentage: '75%',
-        dialogTop: -80
-    },
-    {
-        containerHeight: 99.6, // 100%
-        percentage: '100%',
-        dialogTop: -120
-    }
-];
+var Play_ChatSizeVal = [];
 
 var Play_ChatFontObj = [];
+
+var Play_ChatSizeLegacyMap = [9, 24, 49, 74, 99];
+var Play_ChatSizeLabels = [];
+var Play_ChatOffsetLabels = [];
+var Play_TempCounter = 0;
+
+for (Play_TempCounter = 1; Play_TempCounter <= 100; Play_TempCounter++) {
+    Play_ChatSizeVal.push({
+        containerHeight: Play_TempCounter - 0.4,
+        containerWidth: Play_TempCounter - 0.3,
+        percentage: Play_TempCounter + '%',
+        dialogTop: Play_TempCounter === 100 ? -120 : -(Play_TempCounter + 12)
+    });
+}
+
+for (Play_TempCounter = 0; Play_TempCounter < Play_ChatSizeVal.length; Play_TempCounter++) {
+    Play_ChatSizeLabels.push(Play_ChatSizeVal[Play_TempCounter].percentage);
+}
+
+for (Play_TempCounter = -20; Play_TempCounter <= 20; Play_TempCounter++) {
+    Play_ChatOffsetLabels.push((Play_TempCounter > 0 ? '+' : '') + Play_TempCounter + '%');
+}
+
+Play_MaxChatSizeValue = Play_ChatSizeVal.length - 1;
 
 //Variable initialization end
 
@@ -1822,6 +1814,7 @@ function Play_showChat() {
     Play_ChatPosition();
     Play_ChatBackgroundChange(false);
     Play_chat_container.classList.remove('hide');
+    ChatLive_UpdateLayout(0);
 
     Play_controls[Play_controlsChat].setLabel();
 
@@ -1867,6 +1860,101 @@ function Play_ChatSize(showDialog) {
     Play_SetChatPosString();
 }
 
+function Play_ChatWidth(showDialog) {
+    if (Play_ChatWidthValue > Play_MaxChatSizeValue) Play_ChatWidthValue = Play_MaxChatSizeValue;
+    Play_chat_container.style.width = Play_ChatSizeVal[Play_ChatWidthValue].containerWidth + '%';
+    Play_ChatPosition();
+
+    if (showDialog) Play_showChatBackgroundDialog('Width ' + Play_ChatSizeVal[Play_ChatWidthValue].percentage);
+
+    Main_setItem('ChatWidthValue', Play_ChatWidthValue);
+}
+
+function Play_ChatOffsetFormat(value) {
+    return (value > 0 ? '+' : '') + value + '%';
+}
+
+function Play_ChatOffsetClamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function Play_GetChatHeight() {
+    return Play_ChatSizeVal[Play_ChatSizeValue].containerHeight;
+}
+
+function Play_GetChatWidth() {
+    return Play_ChatSizeVal[Play_ChatWidthValue].containerWidth;
+}
+
+function Play_GetChatBaseTop(isFullSize) {
+    var height = Play_GetChatHeight(),
+        position = Play_ChatPositionVal[Play_ChatPositions];
+
+    if (isFullSize || position.vertical === 'top') {
+        return 0.2;
+    }
+
+    if (position.vertical === 'center') {
+        return 50 - height / 2;
+    }
+
+    return 99.8 - height;
+}
+
+function Play_GetChatBaseLeft(isFullSize) {
+    var width = Play_GetChatWidth(),
+        position = Play_ChatPositionVal[Play_ChatPositions + (isFullSize ? 2 : 0)];
+
+    if (position.horizontal === 'left') {
+        return 0.2;
+    }
+
+    if (position.horizontal === 'center') {
+        return 50 - width / 2;
+    }
+
+    return 99.8 - width;
+}
+
+function Play_MigrateLegacyChatSizeValue(value) {
+    var version = Main_getItemInt('ChatSizeValueVersion', 0);
+
+    if (version >= 3) {
+        return Play_ChatOffsetClamp(value, 0, Play_MaxChatSizeValue);
+    }
+
+    if (version >= 2) {
+        value = value * 5 + 4;
+    } else if (value < 0) {
+        value = 0;
+    } else if (value >= 0 && value < Play_ChatSizeLegacyMap.length) {
+        value = Play_ChatSizeLegacyMap[value];
+    } else if (value > Play_MaxChatSizeValue) {
+        value = Play_MaxChatSizeValue;
+    }
+
+    value = Play_ChatOffsetClamp(value, 0, Play_MaxChatSizeValue);
+
+    Main_setItem('ChatSizeValue', value);
+    Main_setItem('ChatSizeValueVersion', 3);
+
+    return value;
+}
+
+function Play_MigrateLegacyChatWidthValue(value) {
+    if (Main_getItemInt('ChatWidthValueVersion', 0) >= 1) {
+        return Play_ChatOffsetClamp(value, 0, Play_MaxChatSizeValue);
+    }
+
+    value = value * 5 + 4;
+    value = Play_ChatOffsetClamp(value, 0, Play_MaxChatSizeValue);
+
+    Main_setItem('ChatWidthValue', value);
+    Main_setItem('ChatWidthValueVersion', 1);
+
+    return value;
+}
+
 function Play_SetChatPosString() {
     if (Play_ChatSizeValue === Play_MaxChatSizeValue) {
         Play_controls[Play_controlsChatPos].values = STR_CHAT_100_ARRAY;
@@ -1892,15 +1980,23 @@ function Play_ChatPositionConvert(up) {
 }
 
 function Play_ChatPosition() {
-    var bool = Play_ChatSizeValue === Play_MaxChatSizeValue;
+    var bool, height, width, top, left;
+
+    bool = Play_ChatSizeValue === Play_MaxChatSizeValue;
 
     if (Play_ChatPositions < 0) Play_ChatPositions = bool ? 2 : 7;
     else if (Play_ChatPositions > (bool ? 2 : 7)) Play_ChatPositions = 0;
 
-    Play_chat_container.style.top =
-        (bool ? 0.2 : Play_ChatPositionVal[Play_ChatPositions].top + Play_ChatPositionVal[Play_ChatPositions].sizeOffset[Play_ChatSizeValue]) + '%';
+    height = Play_GetChatHeight();
+    width = Play_GetChatWidth();
+    top = Play_GetChatBaseTop(bool) + Play_ChatOffsetYValue;
+    left = Play_GetChatBaseLeft(bool) + Play_ChatOffsetXValue;
 
-    Play_chat_container.style.left = Play_ChatPositionVal[Play_ChatPositions + (bool ? 2 : 0)].left + '%';
+    top = Play_ChatOffsetClamp(top, 0.2, 99.8 - height);
+    left = Play_ChatOffsetClamp(left, 0.2, 99.8 - width);
+
+    Play_chat_container.style.top = top + '%';
+    Play_chat_container.style.left = left + '%';
 
     Main_setItem('ChatPositionsValue', Play_ChatPositions);
 }

--- a/app/specific/PlayEtc.js
+++ b/app/specific/PlayEtc.js
@@ -24,6 +24,11 @@ var Play_isFullScreenOld = null;
 var Play_FullScreenSize = 3;
 var Play_FullScreenPosition = 1;
 var Play_ScreeIsOff = false;
+var Play_ChatPinMentionsValue = 1;
+var Play_ChatPinMentionsCountValue = 2;
+var Play_ChatPinMentionsTimeValue = 2;
+var Play_ChatPinMentionsCountLabels = ['1', '2', '3', '4', '5'];
+var Play_ChatPinMentionsTimeLabels = ['30 seconds', '1 minute', '2 minutes', '5 minutes', '10 minutes', '15 minutes', '30 minutes'];
 
 function Play_screeOn() {
     if (!Play_ScreeIsOff) {
@@ -321,7 +326,7 @@ function Play_SetChatSideBySide() {
 
         //Default values
         Play_chat_container.style.height = '99.6%';
-        Main_getElementById('play_chat_dialog').style.marginTop = Play_ChatSizeVal[3].dialogTop + '%';
+        Main_getElementById('play_chat_dialog').style.marginTop = '-80%';
         Play_chat_container.style.top = '0.2%';
     } else {
         Play_chat_container.style.width = Play_ChatFullScreenSizes[Play_FullScreenPosition][Play_FullScreenSize].width;
@@ -329,7 +334,7 @@ function Play_SetChatSideBySide() {
 
         //Default values
         Play_chat_container.style.height = '99.6%';
-        Main_getElementById('play_chat_dialog').style.marginTop = Play_ChatSizeVal[3].dialogTop + '%';
+        Main_getElementById('play_chat_dialog').style.marginTop = '-80%';
         Play_chat_container.style.top = '0.2%';
 
         if (Main_IsOn_OSInterface) OSInterface_mupdatesize(Play_isFullScreen);
@@ -347,6 +352,7 @@ function Play_SetChatSideBySide() {
 
     Play_ChatEnable = true;
     Play_chat_container.classList.remove('hide');
+    ChatLive_UpdateLayout(0);
 
     if (!Main_IsOn_OSInterface) {
         BrowserTestSetVideoSize();
@@ -358,6 +364,7 @@ function Play_SetChatSideBySide() {
 }
 
 var Play_ChatFullScreenObj = {
+    width: '',
     height: '',
     marginTop: '',
     top: '',
@@ -374,6 +381,7 @@ function Play_StoreChatFullScreen() {
     Play_ChatFullScreenObj.controlsSizeDefault = Play_controls[Play_controlsChatPos].defaultValue;
 
     Play_ChatFullScreenObj.WasEnable = Play_ChatEnable;
+    Play_ChatFullScreenObj.width = Play_chat_container.style.width;
     Play_ChatFullScreenObj.height = Play_chat_container.style.height;
     Play_ChatFullScreenObj.marginTop = Main_getElementById('play_chat_dialog').style.marginTop;
     Play_ChatFullScreenObj.top = Play_chat_container.style.top;
@@ -397,6 +405,7 @@ function Play_ResStoreChatFullScreen() {
         Play_chat_container.style.width = '';
         if (!Play_ChatEnable) Play_hideChat();
         else Play_showChat();
+        Play_chat_container.style.width = Play_ChatFullScreenObj.width;
         Play_chat_container.style.height = Play_ChatFullScreenObj.height;
         Main_getElementById('play_chat_dialog').style.marginTop = Play_ChatFullScreenObj.marginTop;
         Play_chat_container.style.top = Play_ChatFullScreenObj.top;
@@ -1618,7 +1627,7 @@ function Play_MultiKeyDown() {
         Play_showChat();
         Play_chat_container.style.width = '32.8%';
         Play_chat_container.style.height = '65.8%';
-        Main_getElementById('play_chat_dialog').style.marginTop = Play_ChatSizeVal[3].dialogTop + '%';
+        Main_getElementById('play_chat_dialog').style.marginTop = '-80%';
         Play_chat_container.style.top = '0.2%';
         Play_chat_container.style.left = '67%';
 
@@ -2007,6 +2016,12 @@ var Play_controlsChatDisShared = temp_controls_pos++;
 var Play_controlsChatDelay = temp_controls_pos++;
 var Play_controlsChatPos = temp_controls_pos++;
 var Play_controlsChatSize = temp_controls_pos++;
+var Play_controlsChatWidth = temp_controls_pos++;
+var Play_controlsChatOffsetX = temp_controls_pos++;
+var Play_controlsChatOffsetY = temp_controls_pos++;
+var Play_controlsChatPinMentions = temp_controls_pos++;
+var Play_controlsChatPinMentionsCount = temp_controls_pos++;
+var Play_controlsChatPinMentionsTime = temp_controls_pos++;
 var Play_controlsChatBright = temp_controls_pos++;
 var Play_controlsChatFont = temp_controls_pos++;
 
@@ -3352,7 +3367,7 @@ function Play_MakeControls() {
         icons: 'chat-size',
         offsetY: -5,
         string: STR_CHAT_SIZE,
-        values: ['12.5%', '25%', '50%', '75%', '100%'],
+        values: Play_ChatSizeLabels,
         defaultValue: Play_ChatSizeValue,
         isChat: true,
         updown: function (adder) {
@@ -3393,6 +3408,248 @@ function Play_MakeControls() {
                 Play_controls[Play_controlsChatPos].values[Play_controls[Play_controlsChatPos].defaultValue]
             );
 
+            Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
+        },
+        bottomArrows: function () {
+            Play_BottomArrows(this.position);
+        }
+    };
+
+    Play_controls[Play_controlsChatWidth] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'resize-up',
+        offsetY: -5,
+        string: 'Chat width',
+        values: Play_ChatSizeLabels,
+        defaultValue: Play_ChatWidthValue,
+        isChat: true,
+        updown: function (adder) {
+            if (!Play_isChatShown() || !Play_isFullScreen || Play_MultiEnable || Play_Multi_MainBig || PlayExtra_PicturePicture) {
+                return;
+            }
+
+            this.defaultValue += adder;
+
+            if (this.defaultValue < 0) this.defaultValue = 0;
+            else if (this.defaultValue > this.values.length - 1) this.defaultValue = this.values.length - 1;
+
+            Play_ChatWidthValue = this.defaultValue;
+            Play_ChatWidth(true);
+
+            this.setLabel();
+            this.bottomArrows();
+        },
+        setLabel: function () {
+            Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
+        },
+        bottomArrows: function () {
+            Play_BottomArrows(this.position);
+        }
+    };
+
+    Play_controls[Play_controlsChatOffsetX] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'offset',
+        offsetY: -5,
+        string: STR_CHAT_POS + ' ' + STR_LEFT + '/' + STR_RIGHT + ' ' + STR_OFFSET,
+        values: Play_ChatOffsetLabels,
+        defaultValue: Play_ChatOffsetXValue + 20,
+        isChat: true,
+        updown: function (adder) {
+            if (!Play_isChatShown() || !Play_isFullScreen || Play_MultiEnable || Play_Multi_MainBig || PlayExtra_PicturePicture) {
+                return;
+            }
+
+            this.defaultValue += adder;
+
+            if (this.defaultValue < 0) {
+                this.defaultValue = 0;
+            } else if (this.defaultValue > this.values.length - 1) {
+                this.defaultValue = this.values.length - 1;
+            }
+
+            Play_ChatOffsetXValue = this.defaultValue - 20;
+            Play_ChatPosition();
+            Main_setItem('ChatOffsetXValue', Play_ChatOffsetXValue);
+
+            this.setLabel();
+            this.bottomArrows();
+        },
+        setLabel: function () {
+            Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
+        },
+        bottomArrows: function () {
+            Play_BottomArrows(this.position);
+        }
+    };
+
+    Play_controls[Play_controlsChatOffsetY] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'offset',
+        offsetY: -5,
+        string: STR_CHAT_POS + ' ' + STR_TOP + '/' + STR_BOTTOM + ' ' + STR_OFFSET,
+        values: Play_ChatOffsetLabels,
+        defaultValue: Play_ChatOffsetYValue + 20,
+        isChat: true,
+        updown: function (adder) {
+            if (!Play_isChatShown() || !Play_isFullScreen || Play_MultiEnable || Play_Multi_MainBig || PlayExtra_PicturePicture) {
+                return;
+            }
+
+            this.defaultValue += adder;
+
+            if (this.defaultValue < 0) {
+                this.defaultValue = 0;
+            } else if (this.defaultValue > this.values.length - 1) {
+                this.defaultValue = this.values.length - 1;
+            }
+
+            Play_ChatOffsetYValue = this.defaultValue - 20;
+            Play_ChatPosition();
+            Main_setItem('ChatOffsetYValue', Play_ChatOffsetYValue);
+
+            this.setLabel();
+            this.bottomArrows();
+        },
+        setLabel: function () {
+            Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
+        },
+        bottomArrows: function () {
+            Play_BottomArrows(this.position);
+        }
+    };
+
+    Play_controls[Play_controlsChatPinMentions] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'chat',
+        offsetY: -5,
+        string: 'Pin mentions',
+        values: [STR_NO, STR_YES],
+        defaultValue: Play_ChatPinMentionsValue,
+        isChat: true,
+        enterKey: function () {
+            this.defaultValue = this.defaultValue ? 0 : 1;
+            Play_ChatPinMentionsValue = this.defaultValue;
+            Main_setItem('Play_ChatPinMentions', Play_ChatPinMentionsValue);
+            ChatLive_RefreshPinSettings();
+            this.setLabel();
+        },
+        setLabel: function () {
+            Main_textContent('controls_text_summary_' + this.position, '(' + this.values[this.defaultValue] + ')');
+        }
+    };
+
+    Play_controls[Play_controlsChatPinMentionsCount] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'chat-size',
+        offsetY: -5,
+        string: 'Pinned mentions count',
+        values: Play_ChatPinMentionsCountLabels,
+        defaultValue: Play_ChatPinMentionsCountValue,
+        isChat: true,
+        updown: function (adder) {
+            this.defaultValue += adder;
+
+            if (this.defaultValue < 0) this.defaultValue = 0;
+            else if (this.defaultValue > this.values.length - 1) this.defaultValue = this.values.length - 1;
+
+            Play_ChatPinMentionsCountValue = this.defaultValue;
+            Main_setItem('Play_ChatPinMentionsCount', Play_ChatPinMentionsCountValue);
+            ChatLive_RefreshPinSettings();
+
+            this.setLabel();
+            this.bottomArrows();
+        },
+        setLabel: function () {
+            Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
+        },
+        bottomArrows: function () {
+            Play_BottomArrows(this.position);
+        }
+    };
+
+    Play_controls[Play_controlsChatPinMentionsTime] = {
+        ShowInLive: false,
+        ShowInVod: false,
+        ShowInClip: false,
+        ShowInPP: false,
+        ShowInMulti: false,
+        ShowInChat: true,
+        ShowInAudio: false,
+        ShowInAudioPP: false,
+        ShowInAudioMulti: false,
+        ShowInPreview: false,
+        ShowInStay: false,
+        icons: 'chat-delay',
+        offsetY: -5,
+        string: 'Pinned mentions duration',
+        values: Play_ChatPinMentionsTimeLabels,
+        defaultValue: Play_ChatPinMentionsTimeValue,
+        isChat: true,
+        updown: function (adder) {
+            this.defaultValue += adder;
+
+            if (this.defaultValue < 0) this.defaultValue = 0;
+            else if (this.defaultValue > this.values.length - 1) this.defaultValue = this.values.length - 1;
+
+            Play_ChatPinMentionsTimeValue = this.defaultValue;
+            Main_setItem('Play_ChatPinMentionsTime', Play_ChatPinMentionsTimeValue);
+            ChatLive_RefreshPinSettings();
+
+            this.setLabel();
+            this.bottomArrows();
+        },
+        setLabel: function () {
             Main_textContentWithEle(this.doc_name, this.values[this.defaultValue]);
         },
         bottomArrows: function () {
@@ -4513,11 +4770,17 @@ function Play_PreStart() {
     Play_MultiDialogElem = Main_getElementById('dialog_multi');
 
     Play_ChatPositions = Main_getItemInt('ChatPositionsValue', 0);
-    Play_ChatSizeValue = Main_getItemInt('ChatSizeValue', 4);
+    Play_ChatSizeValue = Play_MigrateLegacyChatSizeValue(Main_getItemInt('ChatSizeValue', 4));
+    Play_ChatWidthValue = Play_MigrateLegacyChatWidthValue(Main_getItemInt('ChatWidthValue', 4));
     Play_ChatEnable = Main_getItemBool('ChatEnable', false);
     Play_isFullScreen = Main_getItemBool('Play_isFullScreen', true);
     Play_ChatBackground = (Main_values.ChatBackground * 0.05).toFixed(2);
     Play_ChatDelayValue = Main_getItemInt('Play_ChatDelayValue', 0);
+    Play_ChatOffsetXValue = Play_ChatOffsetClamp(Main_getItemInt('ChatOffsetXValue', 0), -20, 20);
+    Play_ChatOffsetYValue = Play_ChatOffsetClamp(Main_getItemInt('ChatOffsetYValue', 0), -20, 20);
+    Play_ChatPinMentionsValue = Main_getItemInt('Play_ChatPinMentions', Settings_value.pin_mentions.defaultValue);
+    Play_ChatPinMentionsCountValue = Main_getItemInt('Play_ChatPinMentionsCount', Settings_value.pin_mentions_count.defaultValue);
+    Play_ChatPinMentionsTimeValue = Main_getItemInt('Play_ChatPinMentionsTime', Settings_value.pin_mentions_time.defaultValue);
 
     Play_PicturePicturePos = Main_getItemInt('Play_PicturePicturePos', 4);
     Play_PicturePictureSize = Main_getItemInt('Play_PicturePictureSize', 2);
@@ -4555,6 +4818,7 @@ function Play_PreStart() {
     Play_MultiSetPanelInfo();
 
     Play_MakeControls();
+    Play_ChatWidth(false);
     Play_ChatSize(false);
 
     Play_ChatBackgroundChange(false);

--- a/app/specific/PlayExtra.js
+++ b/app/specific/PlayExtra.js
@@ -224,6 +224,8 @@ function PlayExtra_ShowChat() {
     Main_ShowElement('chat_container1');
     Main_ShowElement('chat_container_name0');
     Main_ShowElement('chat_container_name1');
+    ChatLive_UpdateLayout(0);
+    ChatLive_UpdateLayout(1);
 }
 
 function PlayExtra_HideChat() {

--- a/app/specific/Settings.js
+++ b/app/specific/Settings.js
@@ -611,6 +611,21 @@ var Settings_value = {
         values: ['no', 'yes'],
         defaultValue: 2
     },
+    pin_mentions: {
+        //Migrated to dialog
+        values: ['no', 'yes'],
+        defaultValue: 1
+    },
+    pin_mentions_count: {
+        //Migrated to dialog
+        values: ['1', '2', '3', '4', '5'],
+        defaultValue: 2
+    },
+    pin_mentions_time: {
+        //Migrated to dialog
+        values: ['30 seconds', '1 minute', '2 minutes', '5 minutes', '10 minutes', '15 minutes', '30 minutes'],
+        defaultValue: 2
+    },
     highlight_user_send: {
         //Migrated to dialog
         values: ['no', 'yes'],


### PR DESCRIPTION
## Summary

This PR improves fullscreen chat customization, adds pinned mentions, and refines live chat layout behavior.

## Feature 1: Expanded fullscreen chat customization

- change fullscreen `Chat size` from coarse presets to `1%` increments
- add a new fullscreen `Chat width` control with `1%` increments
- add horizontal and vertical chat offset controls for finer placement
- preserve/migrate older saved chat size and width values to the new scale

## Feature 2: Pinned mentions in `Chat extra settings`

- add `Pin mentions`
- add `Pinned mentions count`
- add `Pinned mentions duration`
- pin recent mentions of the signed-in user at the top of chat
- show pinned mentions in a visually distinct section with a conditional `Pinned mentions` header
- show relative age labels such as `30s ago` and `2m ago`
- support duration options from `30 seconds` up to `30 minutes`

## Feature 3: Chat layout/rendering refinements

- refine live chat layout so pinned mentions integrate cleanly into the chat overlay
- adjust chat rendering behavior across playback/chat transitions
- improve wrapped-message visibility and chat containment inside the chat background area

## UI placement change

- move pin-mentions controls into the in-player `Chat extra settings` menu instead of the global app settings area

## Testing

- browser testing for web-app behavior
- Android TV emulator testing
- real Android TV sideload testing
- tested on a TCL Google TV
