### PR TITLE
Gradle: Source sets to exclude crashlytics

### DIFF
--- a/apk/app/build.gradle
+++ b/apk/app/build.gradle
@@ -2,8 +2,11 @@ apply from: '../versions.gradle'
 apply plugin: 'com.android.application'
 
 //Crashlytics
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'com.google.firebase.crashlytics'
+def hasCrashlytics = file('google-services.json').exists()
+if (hasCrashlytics) {
+    apply plugin: 'com.google.gms.google-services'
+    apply plugin: 'com.google.firebase.crashlytics'
+}
 //Crashlytics end
 
 android {
@@ -12,6 +15,14 @@ android {
 
     buildFeatures {
         buildConfig = true
+    }
+
+    sourceSets {
+        main {
+            java.srcDirs += hasCrashlytics
+                ? ['src/crashlytics/java']
+                : ['src/noop/java']
+        }
     }
 
     defaultConfig {
@@ -82,9 +93,11 @@ dependencies {
     //implementation project(':media-lib-decoder-av1')
 
     //Crashlytics
+if (hasCrashlytics) {
     implementation platform('com.google.firebase:firebase-bom:33.14.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-crashlytics'
+}
     //Crashlytics end
 
     implementation 'androidx.leanback:leanback:1.2.0'

--- a/apk/app/src/crashlytics/java/com/fgl27/twitch/CrashlyticsHelper.java
+++ b/apk/app/src/crashlytics/java/com/fgl27/twitch/CrashlyticsHelper.java
@@ -1,0 +1,37 @@
+package com.fgl27.twitch;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+public final class CrashlyticsHelper {
+
+    public static void init(Context context) {
+        FirebaseApp.initializeApp(context);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
+    }
+
+    public static void recordException(String TAG, String message, Throwable e) {
+        try {
+            FirebaseCrashlytics.getInstance().log(TAG + " " + message);
+            if (e != null) {
+                FirebaseCrashlytics.getInstance().recordException(e);
+                Log.w(TAG, message, e);
+            } else {
+                FirebaseCrashlytics.getInstance().recordException(new RuntimeException(TAG + " e " + message));
+                Log.w(TAG, message);
+            }
+            FirebaseCrashlytics.getInstance().sendUnsentReports();
+        } catch (Exception ignore) {
+        }
+    }
+
+    public static void sendUnsentReports() {
+        try {
+            FirebaseCrashlytics.getInstance().sendUnsentReports();
+        } catch (Exception ignore) {
+        }
+    }
+}

--- a/apk/app/src/main/java/com/fgl27/twitch/PlayerActivity.java
+++ b/apk/app/src/main/java/com/fgl27/twitch/PlayerActivity.java
@@ -88,8 +88,7 @@ import androidx.media3.exoplayer.trackselection.MappingTrackSelector;
 import androidx.media3.ui.PlayerView;
 import com.fgl27.twitch.channels.ChannelsUtils;
 import com.fgl27.twitch.notification.NotificationUtils;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.crashlytics.FirebaseCrashlytics;
+import com.fgl27.twitch.CrashlyticsHelper;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
@@ -370,8 +369,7 @@ public class PlayerActivity extends Activity {
             intent.setAction(null);
             setIntent(intent);
 
-            FirebaseApp.initializeApp(this);
-            FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
+            CrashlyticsHelper.init(this);
 
             try {
                 setContentView(R.layout.activity_player);
@@ -445,7 +443,7 @@ public class PlayerActivity extends Activity {
             initializeWebview();
 
             StopNotificationService();
-            FirebaseCrashlytics.getInstance().sendUnsentReports();
+            CrashlyticsHelper.sendUnsentReports();
 
             DataThreadPool.execute(() -> Tools.GetUpdateFile(getApplicationContext()));
 

--- a/apk/app/src/main/java/com/fgl27/twitch/Tools.java
+++ b/apk/app/src/main/java/com/fgl27/twitch/Tools.java
@@ -73,7 +73,7 @@ import androidx.media3.extractor.text.SubtitleParser;
 import androidx.webkit.WebViewCompat;
 import com.fgl27.twitch.DataSource.DefaultHttpDataSource;
 import com.fgl27.twitch.notification.NotificationService;
-import com.google.firebase.crashlytics.FirebaseCrashlytics;
+import com.fgl27.twitch.CrashlyticsHelper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.ByteArrayOutputStream;
@@ -908,20 +908,7 @@ public final class Tools {
     }
 
     public static void recordException(String TAG, String message, Throwable e) {
-        try {
-            FirebaseCrashlytics.getInstance().log(TAG + " " + message);
-
-            if (e != null) {
-                FirebaseCrashlytics.getInstance().recordException(e);
-                Log.w(TAG, message, e);
-            } else {
-                FirebaseCrashlytics.getInstance().recordException(new RuntimeException(TAG + " e " + message));
-                Log.w(TAG, message);
-            }
-
-            FirebaseCrashlytics.getInstance().sendUnsentReports();
-        } catch (Exception ignore) { //Just in case prevent a crash sending a crash
-        }
+    CrashlyticsHelper.recordException(TAG, message, e);
     }
 
     //    static void checkTokens(String UserId, AppPreferences appPreferences) {

--- a/apk/app/src/noop/java/com/fgl27/twitch/CrashlyticsHelper.java
+++ b/apk/app/src/noop/java/com/fgl27/twitch/CrashlyticsHelper.java
@@ -1,0 +1,21 @@
+package com.fgl27.twitch;
+
+import android.content.Context;
+import android.util.Log;
+
+public final class CrashlyticsHelper {
+
+    public static void init(Context context) {
+    }
+
+    public static void recordException(String TAG, String message, Throwable e) {
+        if (e != null) {
+            Log.w(TAG, message, e);
+        } else {
+            Log.w(TAG, message);
+        }
+    }
+
+    public static void sendUnsentReports() {
+    }
+}

--- a/apk/build.gradle
+++ b/apk/build.gradle
@@ -12,8 +12,10 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.13.2'//update gradlew -> ./gradlew wrapper
 
         //Crashlytics
+    if (file('app/google-services.json').exists()) {
         classpath 'com.google.gms:google-services:4.4.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
+    }
         //Crashlytics end
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Adds a source set to exclude Crashlytics module from compiled APK and use no-op functions if google-services.json is missing in project. Assuming that it must be in apk/app/google-services.json

Follows https://github.com/fgl27/SmartTwitchTV/commit/b421b6a504a922da1e0bfd53a29610801c84ff29.diff