### PR TITLE
Add live, VOD and clip deep link support

### DIFF
--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -3409,7 +3409,7 @@ function Main_DeeplinkOpenVodError() {
 }
 
 function Main_DeeplinkOpenClip(id) {
-var clipId = id.split('?')[0],
+    var clipId = id.split('?')[0],
         theUrl;
 
     if (!clipId) {
@@ -3423,7 +3423,7 @@ var clipId = id.split('?')[0],
 }
 
 function Main_DeeplinkOpenClipSuccess(response) {
-response = JSON.parse(response);
+    response = JSON.parse(response);
 
     if (!response.data || !response.data.length) {
         Main_DeeplinkOpenClipError();

--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -3270,13 +3270,48 @@ function Main_onNewIntentClearPlay() {
 function Main_HandleDeeplinkIntent(obj) {
     console.log('Main_HandleDeeplinkIntent', obj);
 
-    var objContent = Main_GetDeeplinkObj(obj);
+    var objContent = Main_GetDeeplinkObj(obj),
+        type = objContent.type ? objContent.type.toLowerCase() : '',
+        content = objContent.content ? objContent.content : '';
+
+    try {
+        content = decodeURIComponent(content);
+    } catch (e) {}
 
     console.log('objContent', objContent);
 
-    //TODO make the handle for the objContent
+    if (type === 'live' && content) {
+        Main_DeeplinkOpenLive(content);
+    }
 
-    Main_EventDEEPLINK(obj);
+    Main_EventDEEPLINK(type, content);
+}
+
+function Main_DeeplinkOpenLive(login) {
+    var theUrl = Main_helix_api + 'streams?user_login=' + encodeURIComponent(login.toLowerCase());
+
+    BaseXmlHttpGet(theUrl, Main_DeeplinkOpenLiveSuccess, Main_DeeplinkOpenLiveError, null, null, true);
+}
+
+function Main_DeeplinkOpenLiveSuccess(response) {
+    response = JSON.parse(response);
+
+    if (response.data && response.data.length) {
+        Main_onNewIntent(
+            JSON.stringify({
+                obj: response.data[0],
+                type: 'LIVE',
+                screen: 2
+            })
+        );
+        return;
+    }
+
+    Main_DeeplinkOpenLiveError();
+}
+
+function Main_DeeplinkOpenLiveError() {
+    console.log('Unable to open live deeplink');
 }
 
 function Main_GetDeeplinkObj(obj) {
@@ -3313,7 +3348,8 @@ function Main_onNewIntent(mobj) {
         } else if (ScreenObj[Main_values.Main_Go].exit_fun) ScreenObj[Main_values.Main_Go].exit_fun();
 
         Play_data = JSON.parse(JSON.stringify(Play_data_base));
-        Play_data.data = ScreensObj_LiveCellArray(obj.obj);
+        Main_values_Play_data = ScreensObj_LiveCellArray(obj.obj);
+        Play_data.data = Main_values_Play_data;
 
         Main_openStream();
 

--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -3282,9 +3282,127 @@ function Main_HandleDeeplinkIntent(obj) {
 
     if (type === 'live' && content) {
         Main_DeeplinkOpenLive(content);
+    } else if (type === 'video' && content) {
+        Main_DeeplinkOpenVod(content);
     }
 
     Main_EventDEEPLINK(type, content);
+}
+
+var Main_DeeplinkVodOffset = 1;
+
+function Main_DeeplinkOpenVod(content) {
+    var vod = Main_DeeplinkParseVod(content),
+        theUrl;
+
+    if (!vod.id) {
+        Main_DeeplinkOpenVodError();
+        return;
+    }
+
+    Main_DeeplinkVodOffset = vod.offset;
+    theUrl = Main_helix_api + 'videos?id=' + encodeURIComponent(vod.id);
+
+    BaseXmlHttpGet(theUrl, Main_DeeplinkOpenVodSuccess, Main_DeeplinkOpenVodError, null, null, true);
+}
+
+function Main_DeeplinkParseVod(content) {
+    var parts = content.split('?'),
+        id = parts[0],
+        offset = 1,
+        query,
+        params,
+        i,
+        pair;
+
+    if (parts.length > 1) {
+        query = parts.slice(1).join('?');
+        params = query.split('&');
+
+        for (i = 0; i < params.length; i++) {
+            pair = params[i].split('=');
+
+            if (pair[0].toLowerCase() === 't' && pair.length > 1) {
+                offset = Main_DeeplinkParseVodTime(decodeURIComponent(pair.slice(1).join('=')));
+                break;
+            }
+        }
+    }
+
+    return {
+        id: id,
+        offset: offset
+    };
+}
+
+function Main_DeeplinkParseVodTime(value) {
+    var hours = 0,
+        minutes = 0,
+        seconds = 0,
+        match;
+
+    if (/^\d+$/.test(value)) {
+        seconds = parseInt(value, 10);
+        return seconds > 0 ? seconds : 1;
+    }
+
+    match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+
+    if (!match) return 1;
+
+    hours = parseInt(match[1] || 0, 10);
+    minutes = parseInt(match[2] || 0, 10);
+    seconds = parseInt(match[3] || 0, 10);
+
+    seconds += minutes * 60 + hours * 3600;
+
+    return seconds > 0 ? seconds : 1;
+}
+
+function Main_DeeplinkOpenVodSuccess(response) {
+    response = JSON.parse(response);
+
+    if (!response.data || !response.data.length) {
+        Main_DeeplinkOpenVodError();
+        return;
+    }
+
+    var data = ScreensObj_VodCellArray(response.data[0], false, null, null);
+
+    Main_clearAllPlayerEvents();
+
+    Play_data = JSON.parse(JSON.stringify(Play_data_base));
+    Main_values_Play_data = data;
+
+    Main_values.Main_selectedChannelDisplayname = data[1];
+    ChannelVod_createdAt = data[2];
+
+    Play_data.data[3] = data[3] ? data[3] : '';
+    ChannelVod_game = Play_data.data[3] ? STR_STARTED + STR_PLAYING + Play_data.data[3] : '';
+    ChannelVod_views = data[4];
+
+    if (data[16]) {
+        Play_data.data[18] = data[16];
+    }
+
+    Main_values.Main_selectedChannel = data[6];
+    Main_values.ChannelVod_vodId = data[7];
+    Main_vodOffset = Main_DeeplinkVodOffset;
+
+    ChannelVod_language = data[9];
+    ChannelVod_title = data[10];
+    Play_DurationSeconds = parseInt(data[11]);
+
+    Main_values.Main_selectedChannel_id = data[14];
+    Main_values.Main_selectedChannelLogo = data[15];
+
+    Main_openVod();
+
+    Main_EventPlay('vod', data[6], data[3], data[9], 'deeplink');
+}
+
+function Main_DeeplinkOpenVodError() {
+    console.log('Unable to open VOD deeplink');
 }
 
 function Main_DeeplinkOpenLive(login) {

--- a/app/specific/Main.js
+++ b/app/specific/Main.js
@@ -1688,6 +1688,7 @@ function Main_openStream() {
 }
 
 function Main_OpenClip(data, id, idsArray, handleKeyDownFunction, screen) {
+    PlayClip_DeeplinkStandalone = false;
     if (Main_ThumbOpenIsNull(id, idsArray[0])) return;
 
     Main_clearAllPlayerEvents();
@@ -3284,6 +3285,8 @@ function Main_HandleDeeplinkIntent(obj) {
         Main_DeeplinkOpenLive(content);
     } else if (type === 'video' && content) {
         Main_DeeplinkOpenVod(content);
+    } else if (type === 'clip' && content) {
+        Main_DeeplinkOpenClip(content);
     }
 
     Main_EventDEEPLINK(type, content);
@@ -3403,6 +3406,73 @@ function Main_DeeplinkOpenVodSuccess(response) {
 
 function Main_DeeplinkOpenVodError() {
     console.log('Unable to open VOD deeplink');
+}
+
+function Main_DeeplinkOpenClip(id) {
+var clipId = id.split('?')[0],
+        theUrl;
+
+    if (!clipId) {
+        Main_DeeplinkOpenClipError();
+        return;
+    }
+
+    theUrl = Main_helix_api + 'clips?id=' + encodeURIComponent(clipId);
+
+    BaseXmlHttpGet(theUrl, Main_DeeplinkOpenClipSuccess, Main_DeeplinkOpenClipError, null, null, true);
+}
+
+function Main_DeeplinkOpenClipSuccess(response) {
+response = JSON.parse(response);
+
+    if (!response.data || !response.data.length) {
+        Main_DeeplinkOpenClipError();
+        return;
+    }
+
+    var data = ScreensObj_ClipCellArray(response.data[0], false, null);
+
+    Main_clearAllPlayerEvents();
+
+    Play_data = JSON.parse(JSON.stringify(Play_data_base));
+    Main_values_Play_data = data;
+
+    ChannelClip_playUrl = data[0];
+    Play_DurationSeconds = parseInt(data[1]);
+    Main_values.Main_selectedChannel_id = data[2];
+
+    Play_data.data[3] = data[3] ? data[3] : '';
+    ChannelClip_game = Play_data.data[3] ? STR_PLAYING + Play_data.data[3] : '';
+    ChannelClip_game_Id = data[18];
+
+    if (ChannelClip_game_Id) {
+        Play_data.data[18] = ChannelClip_game_Id;
+    }
+
+    Main_values.Main_selectedChannelDisplayname = data[4];
+    Main_values.Main_selectedChannelLogo = data[5];
+    ChannelClip_Id = data[7];
+    Main_values.Main_selectedChannel = data[6];
+    Main_values.ChannelVod_vodId = data[8];
+    ChannelVod_vodOffset = parseInt(data[9]);
+
+    ChannelClip_title = data[10];
+    ChannelClip_language = data[11];
+    ChannelClip_createdAt = STR_CREATED_AT + data[16];
+    ChannelClip_views = data[14] + STR_VIEWS;
+
+    Main_hideScene1DocAndCallBack(function () {
+        Main_showScene2Doc();
+        Main_PlayClipHandleKeyDown();
+        PlayClip_DeeplinkStandalone = true;
+        PlayClip_Start();
+
+        Main_EventPlay('clip', data[6], data[3], data[17], 'deeplink');
+    });
+}
+
+function Main_DeeplinkOpenClipError() {
+    console.log('Unable to open clip deeplink');
 }
 
 function Main_DeeplinkOpenLive(login) {

--- a/app/specific/PlayClip.js
+++ b/app/specific/PlayClip.js
@@ -26,6 +26,10 @@ var PlayClip_qualityIndex = 0;
 var PlayClip_qualities = [];
 var PlayClip_playingUrl = '';
 var PlayClip_replayOrNext = false;
+
+// A clip opened directly through a deep link has no clip-list navigation
+// context, so it is treated as standalone playback.
+var PlayClip_DeeplinkStandalone = false;
 var PlayClip_replay = false;
 var PlayClip_HasVOD = false;
 
@@ -100,8 +104,14 @@ function PlayClip_Start() {
     Main_ShowElementWithEle(Play_Controls_Holder);
 
     UserLiveFeed_PreventHide = false;
-    PlayClip_UpdateNext();
-
+    if (PlayClip_DeeplinkStandalone) {
+        PlayClip_HasNext = false;
+        PlayClip_HasBack = false;
+        PlayClip_HideShowNext(0, 0);
+        PlayClip_HideShowNext(1, 0);
+    } else {
+        PlayClip_UpdateNext();
+    }
     Play_SetAudioIcon();
 
     Play_EndSet(3);
@@ -556,6 +566,7 @@ function PlayClip_Enter() {
 }
 
 function PlayClip_PlayNext() {
+    if (PlayClip_DeeplinkStandalone) return;
     PlayClip_PreshutdownStream(false);
 
     Screens_KeyLeftRight(1, 0, Main_values.Main_Go);
@@ -563,6 +574,7 @@ function PlayClip_PlayNext() {
 }
 
 function PlayClip_PlayPreviously() {
+    if (PlayClip_DeeplinkStandalone) return;
     PlayClip_PreshutdownStream(false);
 
     Screens_KeyLeftRight(-1, ScreenObj[Main_values.Main_Go].ColumnsCount - 1, Main_values.Main_Go);

--- a/app/specific/Screens.js
+++ b/app/specific/Screens.js
@@ -160,11 +160,14 @@ function Screens_first_init() {
         live_channel_call,
         game_channel_call,
         screen_channel_call,
+        deeplink_channel_call,
         tempGame;
 
     //
     if (Last_obj) {
         obj = JSON.parse(Last_obj);
+
+        deeplink_channel_call = Main_A_equals_B(obj.type, 'DEEPLINK');
 
         live_channel_call = Main_A_equals_B(obj.type, 'LIVE');
 
@@ -184,7 +187,11 @@ function Screens_first_init() {
     var StartUser = Settings_value.start_user_screen.defaultValue;
     var restore_playback = Settings_value.restor_playback.defaultValue;
 
-    if (live_channel_call) {
+    if (deeplink_channel_call) {
+        Main_values.Play_WasPlaying = 0;
+        StartUser = false;
+        restore_playback = false;
+    } else if (live_channel_call) {
         Main_values.Play_WasPlaying = 1;
 
         Play_data = JSON.parse(JSON.stringify(Play_data_base));
@@ -275,6 +282,10 @@ function Screens_first_init() {
         if (Main_values.IsUpDating) {
             Main_showWarningDialog(STR_UPDATE_WARNING_OK, 5000);
         }
+    }
+
+    if (deeplink_channel_call) {
+        Main_HandleDeeplinkIntent(obj);
     }
 
     Main_ShowElement('topbar');


### PR DESCRIPTION
## Summary

Adds deep link support for directly opening Twitch content in SmartTwitchTV.

Supported deep links:

- Live channels
  - `smarttvtwitch://data/live/<channel>`
- VODs
  - `smarttvtwitch://data/video/<vod_id>`
- VODs with timestamps
  - `smarttvtwitch://data/video/<vod_id>?t=0h19m25s`
  - numeric seconds are also supported
- Clips
  - `smarttvtwitch://data/clip/<clip_slug>`

## Live channels

Live deep links resolve the channel through Helix and open the stream using the existing live playback path.

Tested with both:
- app already running
- cold app start

## VODs

VOD deep links resolve the video through Helix and use the existing VOD playback path.

The optional `t` parameter supports Twitch-style timestamps such as:

`0h19m25s`

as well as a raw number of seconds.

Tested with both:
- app already running
- cold app start

## Clips

Clip deep links resolve the clip through Helix and use the existing clip playback implementation.

A directly opened clip is intentionally treated as standalone playback.

The normal clip next/previous logic depends on an existing clip screen/list navigation context. A clip opened directly through a deep link does not have that context, and trying to continue automatically to a following clip can fail to resolve the next video URL.

For this reason:
- the requested deep-linked clip plays normally
- playback ends normally when the clip finishes
- automatic next/previous clip navigation is disabled for deep-linked clips
- normal clip navigation for clips opened from within the app is unchanged

## Testing

Tested on an Amazon Fire TV Cube using the Android debug build.

Verified:
- live warm start
- live cold start
- VOD warm start
- VOD cold start
- VOD timestamp start
- clip warm start
- clip cold start
- clip playback through completion
- normal end-of-clip behavior without attempting an invalid follow-up clip

Changes were done with help of chatgpt 